### PR TITLE
Unused sun jdk depencency ( import ) removed

### DIFF
--- a/valerie/src/main/java/be/rubus/web/valerie/recording/RecordingInfoPhaseListener.java
+++ b/valerie/src/main/java/be/rubus/web/valerie/recording/RecordingInfoPhaseListener.java
@@ -17,7 +17,6 @@
 package be.rubus.web.valerie.recording;
 
 import be.rubus.web.jerry.provider.BeanProvider;
-import com.sun.scenario.effect.impl.sw.sse.SSEBlend_SRC_OUTPeer;
 
 import javax.faces.event.PhaseEvent;
 import javax.faces.event.PhaseId;


### PR DESCRIPTION
Becouse of this dependency project cannot compile with OpenJDK
